### PR TITLE
fix error message typo

### DIFF
--- a/quickumls/install.py
+++ b/quickumls/install.py
@@ -154,7 +154,7 @@ def parse_args():
         help='Normalize unicode strings to their closest ASCII representation'
     )
     ap.add_argument(
-        '-d', '--database-backend', choices=('unqlite'), default='unqlite',
+        '-d', '--database-backend', choices=('unqlite',), default='unqlite',
         help='KV database to use to store CUIs and semantic types'
     )
     ap.add_argument(


### PR DESCRIPTION
error message was `(choose from 'u', 'n', 'q', 'l', 'i', 't', 'e')`. Fixing that so it now is `(choose from 'unqlite')`